### PR TITLE
fix: prevent identically named top-level items in the left nav

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -290,22 +290,37 @@ function attachModuleSymbols (doclets, modules) {
 function buildMemberNav (items, itemHeading, itemsSeen, linktoFn) {
   var nav = '';
   var itemsNav = '';
+  var nameToLongnames = {};
 
   if (items && items.length) {
+    items.map(function (item) {
+      var name = item.name;
+      var longname = item.longname;
+
+      nameToLongnames[name] = nameToLongnames[name] || [];
+      nameToLongnames[name].push(longname);
+    });
+
     items.forEach(function (item) {
       var methods = find({ kind: 'function', memberof: item.longname });
+      var itemName = item.name;
+
+      // if multiple members have the same 'name', show the 'longname' rather than the 'name' in the nav
+      if (nameToLongnames[item.name].length > 1) {
+        itemName = item.longname;
+      }
 
       if (!hasOwnProp.call(item, 'longname')) {
-        itemsNav += '<li id="' + item.name.replace('/', '_') + '-nav">' + linktoFn('', item.name);
+        itemsNav += '<li id="' + itemName.replace('/', '_') + '-nav">' + linktoFn('', itemName);
         itemsNav += '</li>';
       } else if (!hasOwnProp.call(itemsSeen, item.longname)) {
         // replace '/' in url to match ID in some section
-        itemsNav += '<li id="' + item.name.replace('/', '_') + '-nav">' + linktoFn(item.longname, item.name.replace(/^module:/, ''));
+        itemsNav += '<li id="' + itemName.replace('/', '_') + '-nav">' + linktoFn(item.longname, itemName.replace(/^module:/, ''));
         if (methods.length) {
           itemsNav += "<ul class='methods'>";
 
           methods.forEach(function (method) {
-            itemsNav += '<li data-type="method" id="' + item.name.replace('/', '_') + '-' + method.name + '-nav">';
+            itemsNav += '<li data-type="method" id="' + itemName.replace('/', '_') + '-' + method.name + '-nav">';
             itemsNav += linkto(method.longname, method.name);
             itemsNav += '</li>';
           });


### PR DESCRIPTION
Before this change, if two top-level items had the same `name`, that name appeared twice in the left nav. For example, `v1.Foo` and `v2.Foo` both appeared as `Foo`, and the generated HTML used the `id` attribute `Foo-nav` for both items.

After this change, the left nav shows `v1.Foo` and `v2.Foo` instead, and their `id` attributes are `v1.Foo-nav` and `v2.Foo-nav`, respectively.

This issue was originally observed in the [Cloud Tasks docs](https://googleapis.dev/nodejs/tasks/latest/). I tested the fix with [googleapis/nodejs-tasks](https://github.com/googleapis/nodejs-tasks) and confirmed that it fixed the issue.